### PR TITLE
Dynamically load searchers

### DIFF
--- a/launchii/appsearch.py
+++ b/launchii/appsearch.py
@@ -6,6 +6,11 @@ from launchii.crosssearch import BaseSearch
 
 
 class StartMenuSearch(BaseSearch):
+    
+    @staticmethod
+    def supported_environment(platform: str) -> bool:
+        return platform == "Windows"
+
     def createindex(
         self,
         path=[

--- a/launchii/crosssearch.py
+++ b/launchii/crosssearch.py
@@ -5,6 +5,11 @@ class BaseSearch:
 
     index: dict[str, str] = {}
 
+    @staticmethod
+    def supported_environment(platform: str) -> bool:
+        """Returns true if the searcher will run properly on this platform"""
+        ...
+
     def __init__(self):
         with open("index.json", "r") as f:  # load index
             self.index = json.load(f)

--- a/launchii/gui.py
+++ b/launchii/gui.py
@@ -80,7 +80,7 @@ class launchiiwidget(QtWidgets.QWidget):
         item = self.listwidget.currentItem()
         if item is not None:
             print(item.text())
-            apppath = self.searcher.getPath(item.text())
+            apppath = self.searcher.get_path(item.text())
             if apppath is not None:
                 print(apppath)
                 os.system("open " + apppath)

--- a/launchii/launchii.py
+++ b/launchii/launchii.py
@@ -4,22 +4,29 @@ Usage:
     $ python launchii.py --cli
     $ python launchii.py --gui
 """
+from launchii.crosssearch import BaseSearch
 import sys
 import platform
+import importlib
+import typing as t
 
 import launchii.cli
 import launchii.gui
 
-import launchii.appsearch
-import launchii.macappsearch
+Loader = t.Callable[[str], object]
 
 
-def searcher(system):
-    return (
-        launchii.appsearch.StartMenuSearch()
-        if system == "Windows"
-        else launchii.macappsearch.OSXApplicationSearch()
-    )
+def get_searcher_class(module_name: str, import_module: Loader) -> t.Type[BaseSearch]:
+    pieces = module_name.split(":")
+    actual_module = import_module(pieces[0])
+    return getattr(actual_module, pieces[1])
+
+
+def searcher(system: str, import_module: Loader, packages: t.List[str]) -> BaseSearch:
+    for package in packages:
+        searcher_class = get_searcher_class(package, import_module)
+        if searcher_class.supported_environment(system):
+            return searcher_class()
 
 
 def main(cli, gui, print, args, searcher):
@@ -32,4 +39,17 @@ def main(cli, gui, print, args, searcher):
 
 
 def run():
-    main(launchii.cli, launchii.gui, print, sys.argv, searcher(platform.system()))
+    main(
+        launchii.cli,
+        launchii.gui,
+        print,
+        sys.argv,
+        searcher(
+            platform.system(),
+            importlib.import_module,
+            [
+                "launchii.appsearch:StartMenuSearch",
+                "launchii.macappsearch:OSXApplicationSearch",
+            ],
+        ),
+    )

--- a/launchii/macappsearch.py
+++ b/launchii/macappsearch.py
@@ -14,6 +14,11 @@ rawFileList = {}
 
 
 class OSXApplicationSearch(BaseSearch):
+    
+    @staticmethod
+    def supported_environment(platform: str) -> bool:
+        return platform == "Darwin"
+
     def createIndex(self, path=path) -> OrderedDict:
         # For every filepath in path, find all the folders (no subdirectories) ending in .app and add them to the dict rawFileList
         for i in path:

--- a/tests/test_appsearch.py
+++ b/tests/test_appsearch.py
@@ -1,0 +1,9 @@
+import launchii.appsearch as app
+
+
+def test_active_on_windows():
+    assert True == app.StartMenuSearch.supported_environment("Windows")
+
+
+def test_not_active_elsewhere():
+    assert False == app.StartMenuSearch.supported_environment("Elsewhere")

--- a/tests/test_launchii.py
+++ b/tests/test_launchii.py
@@ -1,3 +1,4 @@
+import importlib
 import unittest.mock as mock
 import pytest
 
@@ -44,11 +45,20 @@ def test_cli_triggered_with_parameter(cli, gui, print_function, searcher):
     cli.main.assert_called_once()
 
 
-def test_searcher_on_windows():
-    assert isinstance(launchii.searcher("Windows"), appsearch.StartMenuSearch)
-
-
-def test_searcher_on_mac():
-    assert isinstance(
-        launchii.searcher("Something Else"), macappsearch.OSXApplicationSearch
+@pytest.mark.parametrize(
+    "platform, expected",
+    [
+        ("Darwin", macappsearch.OSXApplicationSearch),
+        ("Windows", appsearch.StartMenuSearch),
+    ],
+)
+def test_searcher_selected_when_platform(platform, expected):
+    searcher = launchii.searcher(
+        platform,
+        importlib.import_module,
+        [
+            "launchii.appsearch:StartMenuSearch",
+            "launchii.macappsearch:OSXApplicationSearch",
+        ],
     )
+    assert isinstance(searcher, expected)

--- a/tests/test_macappsearch.py
+++ b/tests/test_macappsearch.py
@@ -1,0 +1,9 @@
+import launchii.macappsearch as app
+
+
+def test_active_on_darwin():
+    assert True == app.OSXApplicationSearch.supported_environment("Darwin")
+
+
+def test_not_active_elsewhere():
+    assert False == app.OSXApplicationSearch.supported_environment("Elsewhere")


### PR DESCRIPTION
Main loads list of strings that provide searcher coordinates.
Later we can extract the strings into a file in a config directory
that is loaded, which will mean people can install plugins via a pip
install and update the config. We can eventually let folks update the
config using the app itself.

Main now delegates to searcher classes to determine if they are applicable
to the platform.

Searcher implements supported_environment static function
Implemented for two existing searchers

