### PR TITLE
Run windows commands

### DIFF
--- a/launchii/cli.py
+++ b/launchii/cli.py
@@ -1,8 +1,7 @@
-import os
 from launchii.colours import *
 
 
-def main(searcher=None):
+def main(searcher, runner):
 
     searchterm = input(cyan("Search: ")).lower()  # get search term
 
@@ -28,7 +27,7 @@ def main(searcher=None):
                 )
 
                 if shouldOpen == "y":
-                    os.system("open " + result)
+                    runner(result)
                     break
                 else:
                     break

--- a/launchii/gui.py
+++ b/launchii/gui.py
@@ -26,7 +26,6 @@ class KeyHelper(QtCore.QObject):
                     QtCore.Qt.Key.Key_Right,
                 ):
                     self.pressed.emit()
-                    print("yes")
                     return True
             elif self.widget.textbox.hasFocus():
                 if event.key() in (
@@ -78,12 +77,10 @@ class launchiiwidget(QtWidgets.QWidget):
     def enterpressed(self):
         item = self.listwidget.currentItem()
         if item is not None:
-            print(item.text())
             apppath = self.searcher.get_path(item.text())
             if apppath is not None:
-                print(apppath)
                 self.runner(apppath)
-                self.window.close()
+                self.close()
 
 
 class Worker(QtCore.QThread):

--- a/launchii/gui.py
+++ b/launchii/gui.py
@@ -2,7 +2,6 @@ import sys
 import random
 from PyQt6 import QtCore, QtWidgets, QtGui
 import time
-import os
 
 
 class KeyHelper(QtCore.QObject):
@@ -48,8 +47,9 @@ class KeyHelper(QtCore.QObject):
 
 
 class launchiiwidget(QtWidgets.QWidget):
-    def __init__(self, searcher):
+    def __init__(self, searcher, runner):
         self.searcher = searcher
+        self.runner = runner
         super().__init__()
         layout = QtWidgets.QVBoxLayout(self)
 
@@ -83,7 +83,7 @@ class launchiiwidget(QtWidgets.QWidget):
             apppath = self.searcher.get_path(item.text())
             if apppath is not None:
                 print(apppath)
-                os.system("open " + apppath)
+                self.runner(apppath)
                 self.window.close()
 
 
@@ -115,10 +115,10 @@ class Worker(QtCore.QThread):
             time.sleep(0.1)
 
 
-def main(searcher=None):
+def main(searcher, runner):
     app = QtWidgets.QApplication([])
 
-    widget = launchiiwidget(searcher)
+    widget = launchiiwidget(searcher, runner)
     widget.setWindowFlags(QtCore.Qt.WindowType.FramelessWindowHint)
     widget.resize(600, 200)
     widget.show()

--- a/launchii/gui.py
+++ b/launchii/gui.py
@@ -1,6 +1,5 @@
 import sys
-import random
-from PyQt6 import QtCore, QtWidgets, QtGui
+from PyQt6 import QtCore, QtWidgets
 import time
 
 
@@ -130,7 +129,3 @@ def main(searcher, runner):
     key_helper.pressed.connect(widget.enterpressed)
 
     sys.exit(app.exec())
-
-
-if __name__ == "__main__":
-    main()

--- a/launchii/launchii.py
+++ b/launchii/launchii.py
@@ -4,6 +4,7 @@ Usage:
     $ python launchii.py --cli
     $ python launchii.py --gui
 """
+import os
 import sys
 import platform
 import importlib
@@ -47,11 +48,19 @@ def searcher(system: str, packages: t.List[str]) -> Searcher:
             return searcher_class()
 
 
-def main(cli, gui, print, args, searcher):
+def osxopen(program: str):
+    return os.system("open " + program)
+
+
+def runner(platform: str):
+    return os.startfile if platform == "Windows" else osxopen
+
+
+def main(cli, gui, print, args, searcher, runner):
     if "--cli" in args:
-        cli.main(searcher)
+        cli.main(searcher, runner)
     elif "--gui" in args:
-        gui.main(searcher)
+        gui.main(searcher, runner)
     else:
         print(__doc__)
 
@@ -68,4 +77,5 @@ def run():
             platform.system(),
             load_plugins(pathlib.Path(dirs.user_config_dir), _default_plugins),
         ),
+        runner(platform.system()),
     )

--- a/tests/test_launchii.py
+++ b/tests/test_launchii.py
@@ -1,3 +1,4 @@
+import os
 import unittest.mock as mock
 import pytest
 import json
@@ -27,21 +28,28 @@ def searcher():
     return mock.Mock()
 
 
-def test_default_behavior_prints_documentation(cli, gui, print_function, searcher):
+@pytest.fixture
+def runner():
+    return mock.Mock()
+
+
+def test_default_behavior_prints_documentation(
+    cli, gui, print_function, searcher, runner
+):
     args = []
-    launchii.main(cli, gui, print_function, args, searcher)
+    launchii.main(cli, gui, print_function, args, searcher, runner)
     print_function.assert_called_once_with(launchii.__doc__)
 
 
-def test_gui_triggered_with_parameter(cli, gui, print_function, searcher):
+def test_gui_triggered_with_parameter(cli, gui, print_function, searcher, runner):
     args = ["--gui"]
-    launchii.main(cli, gui, print_function, args, searcher)
+    launchii.main(cli, gui, print_function, args, searcher, runner)
     gui.main.assert_called_once()
 
 
-def test_cli_triggered_with_parameter(cli, gui, print_function, searcher):
+def test_cli_triggered_with_parameter(cli, gui, print_function, searcher, runner):
     args = ["--cli"]
-    launchii.main(cli, gui, print_function, args, searcher)
+    launchii.main(cli, gui, print_function, args, searcher, runner)
     cli.main.assert_called_once()
 
 
@@ -79,3 +87,11 @@ def test_plugins_create_default_files_if_not_found(tmp_path):
     plugin_file = open(tmp_path / "plugins.json", "r")
     assert json.load(plugin_file) == ["a", "b"]
     plugin_file.close()
+
+
+def test_windows_runner():
+    assert launchii.runner("Windows") == os.startfile
+
+
+def test_osx_runner():
+    assert launchii.runner("Darwin") == launchii.osxopen


### PR DESCRIPTION
Make it so runner dependency is injected based on platform.
Eventually make actions plugins as well

Call close on widget instead of widget.window. This was throwing errors on Windows,
let me know if it has issues on OSX.

Also removed some print statements.

At this point the core functionality works perfectly on windows. Going to either work on making actions pluggable, or making it run as a daemon that detects a global shortcut