### PR TITLE
Fix osx app launch bug

### DIFF
--- a/launchii/gui.py
+++ b/launchii/gui.py
@@ -1,3 +1,4 @@
+from launchii.api import Result
 import sys
 from PyQt6 import QtCore, QtWidgets
 import time
@@ -74,7 +75,7 @@ class launchiiwidget(QtWidgets.QWidget):
             self.listwidget.setCurrentIndex(index)
 
     def enterpressed(self):
-        item = self.listwidget.currentItem()
+        item: QListWidgetResult = self.listwidget.currentItem()
         if item is not None:
             apppath = item.launchii_value.location
             if apppath is not None:
@@ -83,7 +84,7 @@ class launchiiwidget(QtWidgets.QWidget):
 
 
 class QListWidgetResult(QtWidgets.QListWidgetItem):
-    launchii_value: str
+    launchii_value: Result
 
 
 class Worker(QtCore.QThread):

--- a/launchii/launchii.py
+++ b/launchii/launchii.py
@@ -14,7 +14,7 @@ import json
 
 import appdirs
 
-from launchii.api import Searcher
+from launchii.api import Location, Searcher
 import launchii.cli
 import launchii.gui
 
@@ -48,8 +48,8 @@ def searcher(system: str, packages: t.List[str]) -> Searcher:
             return searcher_class()
 
 
-def osxopen(program: str):
-    return os.system("open " + program)
+def osxopen(program: Location):
+    return os.system(f'open "{str(program)}"')
 
 
 def runner(platform: str):


### PR DESCRIPTION
I don't have osx but it occured to me the runner is being passed a
path object and is attempting to concatenate a string to it.
Convert path to string and also wrapping in double quotes in case it
contains a space