### PR TITLE
Move plugins into launchiicontrib

### DIFF
--- a/launchii/api.py
+++ b/launchii/api.py
@@ -1,12 +1,35 @@
 """launchii plugin API
 
-By implementing one of the below protocols and then adding
-the coordinates to the object to the launchii main method
-a plugin developer can add arbitrary search capabilities.
+Launchii plugins are created and published to PyPi independently
+of Launchii itself. Launchii plugins should be published into PyPi following
+PEP423 guidance for default community contributions. Which is documented here: https://www.python.org/dev/peps/pep-0423/#id101
+In addition to naming the package correctly they should also implement a special
+class named Index in the root __init__.py file of the package.
+
+e.g.:
+    I am creating a plugin for bookmarks, my package name in PyPi is 'launchiicontrib.bookmarks'
+    and launchiicontrib.bookmarks.Index is a class in my package.
+
+Your Index class, as well as any type objects it returns can be dependency injected
+with launchii services.
+
+e.g.:
+    def __init__(self, system, user_config_dir)
+
+In the above example system and user_config_dir are two of such
+parameters of which there are more.  user_config_dir provides a
+Pathlib.Path to launchii's configuration directory on disk, and
+system provides a string defining the system launchii is running
+inside, such as Windows or Darwin.  There are other parameters as
+well. To understand more details about Index as well as the classes
+it can return please read additional documentation below.
+
+Launchii plugins should always match the major version number of launchii itself, the launchii major version
+represents the API documented in this file, and whenever it changes, plugins will need to release new versions
 """
 
 import pathlib
-from typing import Any, List, Protocol, Union, runtime_checkable
+from typing import Any, List, Protocol, Type, Union
 from dataclasses import dataclass
 
 Location = Union[pathlib.Path, str]
@@ -18,35 +41,9 @@ class Item:
     location: Location
 
 
-class Plugin(Protocol):
-    """Plugins for launchii
-
-    Plugins for launchii, in addition to requiring the
-    supported_environment static method and to implement a
-    plugin protocol that actually does something such as
-    Action or Searcher may also implement a constructor that can
-    accept one or more launchii services via its parameters
-
-    e.g.:
-        def __init__(self, system, user_config_dir)
-
-    In the above example system and user_config_dir are two of such
-    parameters of which there are more.  user_config_dir provides a
-    Pathlib.Path to launchii's configuration directory on disk, and
-    system provides a string defining the system launchii is running
-    inside, such as Windows or Darwin.  There are other parameters as
-    well.
-
-    """
-
-    @staticmethod
-    def supported_environment(platform: str) -> bool:
-        """Returns true if the searcher will run properly on this platform"""
-        ...
-
-
-@runtime_checkable
 class Searcher(Protocol):
+    """To be written"""
+
     def search(self, search_term: str) -> List[Item]:
         """Have this plugin search for a search term
 
@@ -54,8 +51,9 @@ class Searcher(Protocol):
         ...
 
 
-@runtime_checkable
 class Action(Protocol):
+    """To be written"""
+
     def do(self, result: Item) -> Any:
         """Preliminay interface for actions"""
         ...
@@ -76,4 +74,14 @@ class Solution(Protocol):
 
 class Launchii(Protocol):
     def search(self, search_term: str) -> List[Solution]:
+        ...
+
+
+class LaunchiiPluginIndex(Protocol):
+    """Represents a Launchii Plugin Index"""
+
+    def searchers(self) -> List[Type[Searcher]]:
+        ...
+
+    def actions(self) -> List[Type[Action]]:
         ...

--- a/launchiicontrib/appsearch/__init__.py
+++ b/launchiicontrib/appsearch/__init__.py
@@ -1,0 +1,19 @@
+from typing import List, Type
+from launchii.api import Action, Searcher
+from launchiicontrib.appsearch.appsearch import StartMenuSearch, OSXApplicationSearch
+
+
+class Index:
+    def __init__(self, system) -> None:
+        self.system = system
+
+    def searchers(self) -> List[Type[Searcher]]:
+        if self.system == "Darwin":
+            return [OSXApplicationSearch]
+        elif self.system == "Windows":
+            return [StartMenuSearch]
+        else:
+            return []
+
+    def actions(self) -> List[Type[Action]]:
+        return []

--- a/launchiicontrib/appsearch/appsearch.py
+++ b/launchiicontrib/appsearch/appsearch.py
@@ -12,7 +12,7 @@ class FileSearch:
     predicates: List[Callable[[pathlib.Path], bool]] = []
 
     def result_builder(self, file) -> Item:
-        return Item(file.name.lower().replace('.lnk', '').title(), file)
+        return Item(file.name.lower().replace(".lnk", "").title(), file)
 
     def search(self, search_term: str) -> List[Item]:
         return list(
@@ -46,10 +46,6 @@ class StartMenuSearch(FileSearch):
 
     predicates = [lambda path: not path.name.startswith("desktop")]
 
-    @staticmethod
-    def supported_environment(platform: str) -> bool:
-        return platform == "Windows"
-
 
 class OSXApplicationSearch(FileSearch):
 
@@ -63,10 +59,6 @@ class OSXApplicationSearch(FileSearch):
 
     def result_builder(self, file) -> Item:
         return Item(file.stem, file)
-
-    @staticmethod
-    def supported_environment(platform: str) -> bool:
-        return platform == "Darwin"
 
     def getIcon(self, path: pathlib.Path) -> pathlib.Path:
         for i in path.glob(f"Contents/Resources/*.icns"):

--- a/launchiicontrib/openaction/__init__.py
+++ b/launchiicontrib/openaction/__init__.py
@@ -1,0 +1,20 @@
+from launchii.api import Action, Searcher
+from typing import List, Type
+
+from launchiicontrib.openaction.openaction import OSXOpen, WindowsOpen
+
+
+class Index:
+    def __init__(self, system) -> None:
+        self.system = system
+
+    def searchers(self) -> List[Type[Searcher]]:
+        return []
+
+    def actions(self) -> List[Type[Action]]:
+        if self.system == "Darwin":
+            return [OSXOpen]
+        elif self.system == "Windows":
+            return [WindowsOpen]
+        else:
+            return []

--- a/launchiicontrib/openaction/openaction.py
+++ b/launchiicontrib/openaction/openaction.py
@@ -4,18 +4,10 @@ from launchii.api import Item
 
 
 class WindowsOpen:
-    @staticmethod
-    def supported_environment(platform: str) -> bool:
-        return platform == "Windows"
-
     def do(self, item: Item) -> Any:
         return os.startfile(item.location)
 
 
 class OSXOpen:
-    @staticmethod
-    def supported_environment(platform: str) -> bool:
-        return platform == "Darwin"
-
     def do(self, item: Item) -> Any:
         return os.system(f'open "{str(item.location)}"')

--- a/tests/test_appsearch.py
+++ b/tests/test_appsearch.py
@@ -1,5 +1,4 @@
-from launchii.api import Item
-import launchii.appsearch as app
+import launchiicontrib.appsearch.appsearch as app
 import pathlib
 
 import pytest
@@ -26,24 +25,16 @@ def start_menu_search(tmp_path):
     return searcher
 
 
-def test_active_on_windows():
-    assert True == app.StartMenuSearch.supported_environment("Windows")
-
-
-def test_not_active_elsewhere():
-    assert False == app.StartMenuSearch.supported_environment("Elsewhere")
-
-
 def test_includes_lnk_files(tmp_path, start_menu_search):
     setup_files(tmp_path, ["testing.lnk"])
     result = start_menu_search.search("test")
-    assert_results(["testing.lnk"], result)
+    assert_results(["Testing"], result)
 
 
 def test_excludes_files_beginning_with_desktop(tmp_path, start_menu_search):
     setup_files(tmp_path, ["desktop_file.lnk", "testing.lnk"])
     result = start_menu_search.search("test")
-    assert_results(["testing.lnk"], result)
+    assert_results(["Testing"], result)
 
 
 def test_searches_child_directories(tmp_path, start_menu_search):
@@ -51,7 +42,7 @@ def test_searches_child_directories(tmp_path, start_menu_search):
         tmp_path, ["desktop_file.lnk", "testing.lnk", "child/another-test-file.lnk"]
     )
     result = start_menu_search.search("test")
-    assert_results(["testing.lnk", "another-test-file.lnk"], result)
+    assert_results(["Testing", "Another-Test-File"], result)
 
 
 def test_results_sorted_by_name(tmp_path, start_menu_search):
@@ -60,7 +51,7 @@ def test_results_sorted_by_name(tmp_path, start_menu_search):
     assert True == all(
         map(
             lambda i: i[0].name == i[1],
-            (zip(result, ["filea.lnk", "fileb.lnk", "filec.lnk"])),
+            (zip(result, ["Filea", "Fileb", "Filec"])),
         )
     )
 
@@ -79,9 +70,7 @@ def test_integration_test(tmp_path, start_menu_search):
         ],
     )
     result = start_menu_search.search("test")
-    assert_results(
-        ["testing.lnk", "another-test-file.lnk", "link3.lnk", "file4.lnk"], result
-    )
+    assert_results(["Testing", "Another-Test-File", "Link3", "File4"], result)
 
 
 @pytest.fixture
@@ -89,14 +78,6 @@ def osx_search(tmp_path):
     searcher = app.OSXApplicationSearch()
     searcher.roots = [tmp_path]
     return searcher
-
-
-def test_active_on_darwin():
-    assert True == app.OSXApplicationSearch.supported_environment("Darwin")
-
-
-def test_not_active_not_on_darwin():
-    assert False == app.OSXApplicationSearch.supported_environment("Elsewhere")
 
 
 def test_darwin_applications(tmp_path, osx_search):

--- a/tests/test_launchii.py
+++ b/tests/test_launchii.py
@@ -1,9 +1,10 @@
 import unittest.mock as mock
+import pinject
 import pytest
 import json
 
-import launchii.appsearch as appsearch
-import launchii.openaction as openaction
+import launchiicontrib.appsearch.appsearch as appsearch
+import launchiicontrib.openaction.openaction as openaction
 import launchii.launchii as launchii
 
 
@@ -53,19 +54,25 @@ def test_cli_triggered_with_parameter(cli, gui, print_function, launchiiApp):
     ],
 )
 def test_plugins_load_when_platform(platform, expected_searchers, expected_actions):
-    class MockInstantiator(object):
-        pass
+    class TestProviderSpec(pinject.BindingSpec):
+        def provide_app_dirs(self):
+            return None
 
-    instantiator = MockInstantiator()
-    instantiator.provide = lambda x: x()
+        def provide_user_config_dir(self, app_dirs):
+            return None
+
+        def provide_system(self):
+            return platform
+
+    instantiator = pinject.new_object_graph(
+        modules=None, binding_specs=[TestProviderSpec()]
+    )
 
     (searchers, actions) = launchii.instantiate_plugins(
         platform,
         [
-            "launchii.appsearch:StartMenuSearch",
-            "launchii.appsearch:OSXApplicationSearch",
-            "launchii.openaction:WindowsOpen",
-            "launchii.openaction:OSXOpen",
+            "launchiicontrib.appsearch",
+            "launchiicontrib.openaction",
         ],
         instantiator,
     )

--- a/tests/test_openaction.py
+++ b/tests/test_openaction.py
@@ -1,15 +1,2 @@
-import launchii.openaction as openaction
+import launchiicontrib.openaction.openaction as openaction
 import pytest
-
-
-@pytest.mark.parametrize(
-    "platform, clazz_, expected",
-    [
-        ("Darwin", openaction.OSXOpen, True),
-        ("Windows", openaction.OSXOpen, False),
-        ("Darwin", openaction.WindowsOpen, False),
-        ("Windows", openaction.WindowsOpen, True),
-    ],
-)
-def test_environment_support(platform, clazz_, expected):
-    assert expected == clazz_.supported_environment(platform)


### PR DESCRIPTION
Move open and file search plugins into launchiicontrib
Update main method to load Index classes instead of individual plugins
Remove supported_environment as no longer explicitly needed