### PR TITLE
Plugin searcher and actions

### DIFF
--- a/launchii/api.py
+++ b/launchii/api.py
@@ -54,8 +54,15 @@ class Searcher(Protocol):
 class Action(Protocol):
     """To be written"""
 
+    def can_do(self, result: SearchResult) -> bool:
+        ...
+
     def do(self, result: SearchResult) -> Any:
         """Preliminay interface for actions"""
+        ...
+
+    def display(self) -> str:
+        """Return a verb describing the action"""
         ...
 
 

--- a/launchii/core.py
+++ b/launchii/core.py
@@ -16,7 +16,7 @@ class BasicSolution:
         self.action = action
 
     def describe(self) -> str:
-        return str(self.item.display())
+        return self.action.display() + " " + self.item.display()
 
     def execute(self) -> Any:
         return self.action.do(self.item)
@@ -82,13 +82,20 @@ class PluginLaunchii:
 
     def search(self, search_term: str) -> List[Solution]:
         searchers = self.plugin_manager.get_active_searchers()
-        action = self.plugin_manager.get_active_actions()[0]
+        actions = self.plugin_manager.get_active_actions()
+
+        search_results = list(
+            itertools.chain.from_iterable(
+                map(lambda searcher: searcher.search(search_term), searchers)
+            )
+        )
 
         return list(
             map(
-                lambda item: BasicSolution(item, action),
-                itertools.chain.from_iterable(
-                    map(lambda searcher: searcher.search(search_term), searchers)
+                lambda combo: BasicSolution(*combo),
+                filter(
+                    lambda combo: combo[1].can_do(combo[0]),
+                    itertools.product(search_results, actions),
                 ),
             )
         )

--- a/launchii/core.py
+++ b/launchii/core.py
@@ -1,13 +1,8 @@
-from typing import Any, List, Tuple
-import pathlib
-import json
-import importlib
-import sys
+from typing import Any, List
 import itertools
 
-import pinject
-
-from launchii.api import Action, SearchResult, Searcher, Solution
+from launchii.api import Action, SearchResult, Solution
+from launchii.plugins import PluginManager
 
 
 class BasicSolution:
@@ -20,60 +15,6 @@ class BasicSolution:
 
     def execute(self) -> Any:
         return self.action.do(self.item)
-
-
-class PluginManager:
-    def __init__(self, user_config_dir, bootstrap_provider_spec) -> None:
-        self.user_config_dir = user_config_dir
-        self.boostrap_provider_spec = bootstrap_provider_spec
-
-    def get_active_searchers(self) -> List[Searcher]:
-        plugin_list = self._get_plugin_list_from_config()
-        (searchers, _) = self._instantiate_plugins(plugin_list)
-        return searchers
-
-    def get_active_actions(self) -> List[Action]:
-        plugin_list = self._get_plugin_list_from_config()
-        (_, actions) = self._instantiate_plugins(plugin_list)
-        return actions
-
-    def _get_plugin_list_from_config(self):
-        return self._load_plugin_file(
-            self.user_config_dir,
-            ["launchiicontrib.appsearch", "launchiicontrib.openaction"],
-        )
-
-    def _load_plugin_file(self, config_dir: pathlib.Path, default) -> List[str]:
-        try:
-            with open(config_dir / "plugins.json") as f:
-                return default
-        except FileNotFoundError as err:
-            config_dir.mkdir(parents=True, exist_ok=True)
-            with open(config_dir / "plugins.json", "w") as f:
-                json.dump(default, f)
-            return default
-
-    def _instantiate_plugins(
-        self,
-        packages: List[str],
-    ) -> Tuple[List[Searcher], List[Action]]:
-
-        searchers: List[Searcher] = []
-        actions: List[Action] = []
-
-        modules = list(map(importlib.import_module, packages))
-        instantiator = pinject.new_object_graph(
-            modules=modules + [sys.modules[__name__]],
-            binding_specs=[self.boostrap_provider_spec],
-        )
-
-        for module in modules:
-            index_class = getattr(module, "Index")
-            index = instantiator.provide(index_class)
-            searchers.extend(map(instantiator.provide, index.searchers()))
-            actions.extend(map(instantiator.provide, index.actions()))
-
-        return (searchers, actions)
 
 
 class PluginLaunchii:

--- a/launchii/launchii.py
+++ b/launchii/launchii.py
@@ -40,7 +40,8 @@ def run():
             return self
 
     instantiator = pinject.new_object_graph(
-        modules=[launchii.core], binding_specs=[BoostrapProviderSpec()]
+        modules=[launchii.core, launchii.plugins],
+        binding_specs=[BoostrapProviderSpec()],
     )
 
     launchiiApp = instantiator.provide(PluginLaunchii)

--- a/launchii/plugins.py
+++ b/launchii/plugins.py
@@ -1,0 +1,134 @@
+from typing import Any, List, Tuple, Type
+import pathlib
+import json
+import importlib
+import sys
+
+import pinject
+
+from launchii.api import Action, LaunchiiPluginIndex, SearchResult, Searcher
+
+
+class PluginSearchResult(SearchResult):
+    def __init__(self, plugin_string: str, active: bool) -> None:
+        self._plugin_string = plugin_string
+        self._active = active
+
+    def display(self) -> str:
+        return self._plugin_string
+
+    def uri(self) -> str:
+        return f"plugin:{self._active}:{self._plugin_string}"
+
+
+class PluginSearcher(Searcher):
+    def __init__(self, plugin_manager) -> None:
+        self.plugin_manager = plugin_manager
+
+    def search(self, search_term: str) -> List[SearchResult]:
+
+        match = (
+            lambda plugin: search_term.lower() in plugin.lower()
+            and plugin != "launchii.core"
+        )
+        build = lambda active: lambda plugin: PluginSearchResult(plugin, active)
+
+        return list(
+            map(build(True), filter(match, self.plugin_manager.active_plugins))
+        ) + list(map(build(False), filter(match, self.plugin_manager.inactive_plugins)))
+
+
+class ActivatePlugin(Action):
+    def __init__(self, plugin_manager) -> None:
+        self.plugin_manager = plugin_manager
+
+    def can_do(self, result: SearchResult) -> bool:
+        return result.uri().startswith("plugin:False")
+
+    def do(self, result: SearchResult) -> Any:
+        print(f"To implement: activate plugin {result.display()}")
+
+    def display(self) -> str:
+        return "activate"
+
+
+class DeactivatePlugin(Action):
+    def __init__(self, plugin_manager) -> None:
+        self.plugin_manager = plugin_manager
+
+    def can_do(self, result: SearchResult) -> bool:
+        return result.uri().startswith("plugin:True")
+
+    def do(self, result: SearchResult) -> Any:
+        print(f"To implement: deactivate plugin {result.display()}")
+
+    def display(self) -> str:
+        return "deactivate"
+
+
+class Index(LaunchiiPluginIndex):
+    def searchers(self) -> List[Type[Searcher]]:
+        return [PluginSearcher]
+
+    def actions(self) -> List[Type[Action]]:
+        return [ActivatePlugin, DeactivatePlugin]
+
+
+class PluginManager:
+    def __init__(self, user_config_dir, bootstrap_provider_spec) -> None:
+        self.user_config_dir = user_config_dir
+        self.boostrap_provider_spec = bootstrap_provider_spec
+        self.active_plugins = [
+            "launchiicontrib.appsearch",
+            "launchiicontrib.openaction",
+            "launchii.plugins",
+        ]
+        self.inactive_plugins: List[str] = []
+
+    def get_active_searchers(self) -> List[Searcher]:
+        plugin_list = self._get_plugin_list_from_config()
+        (searchers, _) = self._instantiate_plugins(plugin_list)
+        return searchers
+
+    def get_active_actions(self) -> List[Action]:
+        plugin_list = self._get_plugin_list_from_config()
+        (_, actions) = self._instantiate_plugins(plugin_list)
+        return actions
+
+    def _get_plugin_list_from_config(self):
+        return self._load_plugin_file(
+            self.user_config_dir,
+            self.active_plugins,
+        )
+
+    def _load_plugin_file(self, config_dir: pathlib.Path, default) -> List[str]:
+        try:
+            with open(config_dir / "plugins.json") as f:
+                return default
+        except FileNotFoundError as err:
+            config_dir.mkdir(parents=True, exist_ok=True)
+            with open(config_dir / "plugins.json", "w") as f:
+                json.dump(default, f)
+            return default
+
+    def _instantiate_plugins(
+        self,
+        packages: List[str],
+    ) -> Tuple[List[Searcher], List[Action]]:
+
+        searchers: List[Searcher] = []
+        actions: List[Action] = []
+
+        modules = list(map(importlib.import_module, packages))
+        instantiator = pinject.new_object_graph(
+            modules=modules + [sys.modules[__name__]],
+            binding_specs=[self.boostrap_provider_spec],
+        )
+
+        for module in modules:
+            index_class = getattr(module, "Index")
+            index = instantiator.provide(index_class)
+            searchers.extend(map(instantiator.provide, index.searchers()))
+            actions.extend(map(instantiator.provide, index.actions()))
+
+        return (searchers, actions)

--- a/launchiicontrib/openaction/openaction.py
+++ b/launchiicontrib/openaction/openaction.py
@@ -7,7 +7,19 @@ class WindowsOpen:
     def do(self, item: SearchResult) -> Any:
         return os.startfile(item.uri())
 
+    def can_do(self, item: SearchResult) -> bool:
+        return item.uri().startswith("file:")
+
+    def display(self) -> str:
+        return "open"
+
 
 class OSXOpen:
     def do(self, item: SearchResult) -> Any:
         return os.system(f'open "{str(item.uri())}"')
+
+    def can_do(self, item: SearchResult) -> bool:
+        return item.uri().startswith("file:")
+
+    def display(self) -> str:
+        return "open"

--- a/tests/launchii/test_core.py
+++ b/tests/launchii/test_core.py
@@ -1,12 +1,7 @@
-from launchii.api import SearchResult
 import pytest
 from unittest.mock import Mock
-import pinject
-import json
 
-from launchii.core import PluginLaunchii, PluginManager
-import launchiicontrib.appsearch.appsearch as appsearch
-import launchiicontrib.openaction.openaction as openaction
+from launchii.core import PluginLaunchii
 
 
 class MockSearchResult:
@@ -18,66 +13,6 @@ class MockSearchResult:
 
     def uri(self) -> str:
         return "mock:" + self._key
-
-
-class FakeProviderSpec(pinject.BindingSpec):
-    def __init__(self, system) -> None:
-        self.system = system
-
-    def provide_app_dirs(self):
-        return None
-
-    def provide_user_config_dir(self, app_dirs):
-        return None
-
-    def provide_system(self):
-        return self.system
-
-
-@pytest.mark.parametrize(
-    "system, expected_searchers, expected_actions",
-    [
-        ("Darwin", [appsearch.OSXApplicationSearch], [openaction.OSXOpen]),
-        ("Windows", [appsearch.StartMenuSearch], [openaction.WindowsOpen]),
-    ],
-)
-def test_plugins_load_when_platform(system, expected_searchers, expected_actions):
-
-    (searchers, actions) = PluginManager(
-        None, FakeProviderSpec(system)
-    )._instantiate_plugins(
-        [
-            "launchiicontrib.appsearch",
-            "launchiicontrib.openaction",
-        ],
-    )
-
-    assert isinstance(searchers[0], expected_searchers[0])
-    assert isinstance(actions[0], expected_actions[0])
-
-
-def test_plugins_always_returning_defaults(tmp_path):
-    plugin_file = open(tmp_path / "plugins.json", "w+")
-    json.dump(["x", "y"], plugin_file)
-    plugin_file.close()
-    assert PluginManager(None, FakeProviderSpec("test"))._load_plugin_file(
-        tmp_path, ["a", "b"]
-    ) == ["a", "b"]
-
-
-def test_plugins_default_if_file_not_found(tmp_path):
-    assert PluginManager(None, FakeProviderSpec("test"))._load_plugin_file(
-        tmp_path, ["a", "b"]
-    ) == ["a", "b"]
-
-
-def test_plugins_create_default_files_if_not_found(tmp_path):
-    assert PluginManager(None, FakeProviderSpec("test"))._load_plugin_file(
-        tmp_path, ["a", "b"]
-    ) == ["a", "b"]
-    plugin_file = open(tmp_path / "plugins.json", "r")
-    assert json.load(plugin_file) == ["a", "b"]
-    plugin_file.close()
 
 
 @pytest.fixture

--- a/tests/launchii/test_plugins.py
+++ b/tests/launchii/test_plugins.py
@@ -1,0 +1,68 @@
+import json
+
+import pytest
+import pinject
+
+import launchiicontrib.appsearch.appsearch as appsearch
+import launchiicontrib.openaction.openaction as openaction
+from launchii.plugins import PluginManager
+
+
+class FakeProviderSpec(pinject.BindingSpec):
+    def __init__(self, system) -> None:
+        self.system = system
+
+    def provide_app_dirs(self):
+        return None
+
+    def provide_user_config_dir(self, app_dirs):
+        return None
+
+    def provide_system(self):
+        return self.system
+
+
+@pytest.mark.parametrize(
+    "system, expected_searchers, expected_actions",
+    [
+        ("Darwin", [appsearch.OSXApplicationSearch], [openaction.OSXOpen]),
+        ("Windows", [appsearch.StartMenuSearch], [openaction.WindowsOpen]),
+    ],
+)
+def test_plugins_load_when_platform(system, expected_searchers, expected_actions):
+
+    (searchers, actions) = PluginManager(
+        None, FakeProviderSpec(system)
+    )._instantiate_plugins(
+        [
+            "launchiicontrib.appsearch",
+            "launchiicontrib.openaction",
+        ],
+    )
+
+    assert isinstance(searchers[0], expected_searchers[0])
+    assert isinstance(actions[0], expected_actions[0])
+
+
+def test_plugins_always_returning_defaults(tmp_path):
+    plugin_file = open(tmp_path / "plugins.json", "w+")
+    json.dump(["x", "y"], plugin_file)
+    plugin_file.close()
+    assert PluginManager(None, FakeProviderSpec("test"))._load_plugin_file(
+        tmp_path, ["a", "b"]
+    ) == ["a", "b"]
+
+
+def test_plugins_default_if_file_not_found(tmp_path):
+    assert PluginManager(None, FakeProviderSpec("test"))._load_plugin_file(
+        tmp_path, ["a", "b"]
+    ) == ["a", "b"]
+
+
+def test_plugins_create_default_files_if_not_found(tmp_path):
+    assert PluginManager(None, FakeProviderSpec("test"))._load_plugin_file(
+        tmp_path, ["a", "b"]
+    ) == ["a", "b"]
+    plugin_file = open(tmp_path / "plugins.json", "r")
+    assert json.load(plugin_file) == ["a", "b"]
+    plugin_file.close()

--- a/tests/launchiicontrib/openaction/test_openaction.py
+++ b/tests/launchiicontrib/openaction/test_openaction.py
@@ -1,2 +1,28 @@
 import launchiicontrib.openaction.openaction as openaction
 import pytest
+from unittest.mock import Mock
+
+
+from launchiicontrib.openaction.openaction import OSXOpen, WindowsOpen
+
+
+def test_osx_can_open_files():
+    action = OSXOpen()
+    test_result = Mock()
+    test_result.uri.return_value = "file://something"
+    assert action.can_do(test_result) is True
+
+
+def test_windows_can_open_files():
+    action = WindowsOpen()
+    test_result = Mock()
+    test_result.uri.return_value = "file://something"
+    assert action.can_do(test_result) is True
+
+
+def test_windows_verb():
+    assert WindowsOpen().display() == "open"
+
+
+def test_osx_verb():
+    assert OSXOpen().display() == "open"


### PR DESCRIPTION
Enable multiple actions per SearchResult 
Plugins as search results
Stubs for activating and deactivating plugins

Next going to refactor the configuration mechanism so activating and deactivating plugins get persisted to disk, also will need to make another plugin in a different repo and build it/publish to pypi  to develop the plugin install workflow